### PR TITLE
fix multiple declared mods not showing all combos

### DIFF
--- a/assets/ng/mods/mods.detail.js
+++ b/assets/ng/mods/mods.detail.js
@@ -12,7 +12,7 @@ angular.module('JunkyardApp.mods')
             $scope.combos = [];
             for (var i = 0; i < $scope.junk.length; i++) {
                 for (var j = 0; j < $scope.junk.length; j++) {
-                    if ($scope.getModifier($scope.junk[i], $scope.junk[j]) == $scope.thisMod) {
+                    if ($scope.getModifier($scope.junk[i], $scope.junk[j]).n == $scope.thisMod.n) {
                         $scope.combos.push([$scope.junk[i], $scope.junk[j]]);
                     }
                 }


### PR DESCRIPTION
stuff like Heal Action Cost Reduction is declared twice in mods.json, so comparing the (full mods) first instance with the second instance gives you a false. comparing the names between them is true, seems like the easiest fix.